### PR TITLE
Sensless part remove and style improvements

### DIFF
--- a/switch.lua
+++ b/switch.lua
@@ -5,7 +5,7 @@ _G.switch = function(param, case_table)
     local case = case_table[param]
     if case then return case() end
     local def = case_table['default']
-    return def and def() or nil
+    return def and def()
 end
 
 --[[

--- a/switch.lua
+++ b/switch.lua
@@ -1,7 +1,7 @@
 --https://github.com/Purple-CARD/glua-or-lua-shit from u with <3
 --https://gist.github.com/FreeBirdLjj/6303864 original
 
-_G.switch = function(param, case_table)
+function switch(param, case_table)
     local case = case_table[param]
     if case then return case() end
     local def = case_table['default']


### PR DESCRIPTION
```def and def()``` is equal to ```def and def() or nil```